### PR TITLE
Fixes for LESS variable usage in filters (background-gradient, opacity)

### DIFF
--- a/helpless.1.0.0.less
+++ b/helpless.1.0.0.less
@@ -362,7 +362,7 @@
   ************************************/
   .background-gradient(@colourfrom: #bbb, @colourTo: #f1f1f1, @fallbackColour: #f1f1f1, @fallbackImageUrl: '') {
     background-color: @fallbackColour;
-    background-image: url(@fallbackImageUrl);
+    background-image: url("@{fallbackImageUrl}");
     background-repeat: no-repeat;
     background-image: -webkit-gradient(linear, 0% 0%, 0% 100%, from(@colourfrom), to(@colourTo));
     background-image: -webkit-linear-gradient(bottom, @colourfrom, @colourTo);

--- a/helpless.1.0.0.less
+++ b/helpless.1.0.0.less
@@ -239,9 +239,9 @@
   ************************************/
   .opacity(@value: .5) {
     opacity: @value;
-    filter: ~'alpha(opacity=(@value*100))'; 
-    filter: ~'progid:DXImageTransform.Microsoft.Alpha(opacity=(@value*100))'; 
-    -ms-filter: ~'"progid:DXImageTransform.Microsoft.Alpha(opacity=(@value*100))"'; 
+    filter: ~'alpha(opacity=(@{value}*100))'; 
+    filter: ~'progid:DXImageTransform.Microsoft.Alpha(opacity=(@{value}*100))'; 
+    -ms-filter: ~'"progid:DXImageTransform.Microsoft.Alpha(opacity=(@{value}*100))"'; 
   }
 
   /************************************
@@ -370,9 +370,9 @@
     background-image: -ms-linear-gradient(bottom, @colourfrom, @colourTo);
     background-image: -o-linear-gradient(bottom, @colourfrom, @colourTo);
     /* For Internet Explorer 5.5 - 7 */
-    filter: progid:DXImageTransform.Microsoft.gradient(startColorstr=@colourfrom, endColorstr=@colourTo);
+    filter: ~'progid:DXImageTransform.Microsoft.gradient(startColorstr=@{colourfrom}, endColorstr=@{colourTo})';
     /* For Internet Explorer 8 and newer */
-    -ms-filter: progid:DXImageTransform.Microsoft.gradient(startColorstr=@colourfrom, endColorstr=@colourTo);
+    -ms-filter: ~'progid:DXImageTransform.Microsoft.gradient(startColorstr=@{colourfrom}, endColorstr=@{colourTo})';
   }
 
   /************************************

--- a/helpless.1.0.0.less
+++ b/helpless.1.0.0.less
@@ -362,7 +362,7 @@
   ************************************/
   .background-gradient(@colourfrom: #bbb, @colourTo: #f1f1f1, @fallbackColour: #f1f1f1, @fallbackImageUrl: '') {
     background-color: @fallbackColour;
-    background-image: url("@fallbackImage");
+    background-image: url(@fallbackImageUrl);
     background-repeat: no-repeat;
     background-image: -webkit-gradient(linear, 0% 0%, 0% 100%, from(@colourfrom), to(@colourTo));
     background-image: -webkit-linear-gradient(bottom, @colourfrom, @colourTo);
@@ -370,9 +370,9 @@
     background-image: -ms-linear-gradient(bottom, @colourfrom, @colourTo);
     background-image: -o-linear-gradient(bottom, @colourfrom, @colourTo);
     /* For Internet Explorer 5.5 - 7 */
-    filter: ~'progid:DXImageTransform.Microsoft.gradient(startColorstr=@colourfrom, endColorstr=@colourTo)';
+    filter: progid:DXImageTransform.Microsoft.gradient(startColorstr=@colourfrom, endColorstr=@colourTo);
     /* For Internet Explorer 8 and newer */
-    -ms-filter: ~'"progid:DXImageTransform.Microsoft.gradient(startColorstr=@colourfrom, endColorstr=@colourTo)"';
+    -ms-filter: progid:DXImageTransform.Microsoft.gradient(startColorstr=@colourfrom, endColorstr=@colourTo);
   }
 
   /************************************


### PR DESCRIPTION
LESS do not substitute variables when they are used like

```
filter: ~'progid:DXImageTransform.Microsoft.Alpha(opacity=(@value*100))';
```

Instead we should use

```
filter: ~'progid:DXImageTransform.Microsoft.Alpha(opacity=(@{value}*100))';
```

and it will output the right value.

This commit fixes that. Please be advised that I've used lessc 1.2.0 and less.js 1.1.6 for testing; it's possible that this fix will break parsing with earlier versions.

[Also, I haven't tested yet whether we could stop using the LESS-specific escaping (I mean the ~' in front of progid) with the actual LESS versions.]
