### PR TITLE
bug fixes opacity and background-gradient

### DIFF
--- a/helpless.1.0.1.less
+++ b/helpless.1.0.1.less
@@ -261,6 +261,9 @@
   *
   ************************************/
   .opacity(@value: .5) {
+	  -moz-opacity: @value;
+	  -khtml-opacity: @value;
+	  -webkit-opacity: @value;
     opacity: @value;
     filter: ~'alpha(opacity=(@value*100))'; 
     filter: ~'progid:DXImageTransform.Microsoft.Alpha(opacity=(@value*100))'; 
@@ -383,19 +386,16 @@
   *          fallbackImageUrl, default = ''
   *
   ************************************/
-  .background-gradient(@colourfrom: #bbb, @colourTo: #f1f1f1, @fallbackColour: #f1f1f1, @fallbackImageUrl: '') {
+  .background-gradient(@colourfrom: #bbb, @colourTo: #f1f1f1, @fallbackColour: #f1f1f1, @fallbackImageUrl: '',@repeat:no-repeat) {
     background-color: @fallbackColour;
-    background-image: url("@fallbackImage");
-    background-repeat: no-repeat;
+    background-image: url(@fallbackImageUrl);
+    background-repeat: @repeat;
+		
     background-image: -webkit-gradient(linear, 0% 0%, 0% 100%, from(@colourfrom), to(@colourTo));
     background-image: -webkit-linear-gradient(bottom, @colourfrom, @colourTo);
     background-image: -moz-linear-gradient(bottom, @colourfrom, @colourTo);
     background-image: -ms-linear-gradient(bottom, @colourfrom, @colourTo);
     background-image: -o-linear-gradient(bottom, @colourfrom, @colourTo);
-    /* For Internet Explorer 5.5 - 7 */
-    filter: ~'progid:DXImageTransform.Microsoft.gradient(startColorstr=@colourfrom, endColorstr=@colourTo)';
-    /* For Internet Explorer 8 and newer */
-    -ms-filter: ~'"progid:DXImageTransform.Microsoft.gradient(startColorstr=@colourfrom, endColorstr=@colourTo)"';
   }
 
   /************************************


### PR DESCRIPTION
Added browser specific opacity rules for opacity
Removed filters from the gradient function because not working properly in ie and added repeat var in gradient function.
Fixed bug @fallbackImageUrl in #hl.background-gradient()
